### PR TITLE
Changed type of _currentFrame as it can be a double too

### DIFF
--- a/lib/display/movie_clip.dart
+++ b/lib/display/movie_clip.dart
@@ -21,9 +21,9 @@ class MovieClip extends Sprite {
   Function onComplete = null;
 
 
-  int _currentFrame = 0;
+  num _currentFrame = 0;
   /// [read-only] The MovieClips current frame index (this may not have to be a whole number)
-  int get currentFrame => _currentFrame;
+  num get currentFrame => _currentFrame;
 
   bool _playing = false;
 


### PR DESCRIPTION
I ran across this error in the Dart Editor as the debugger showed me an exception on line 24 of this file. As the comment already says, the value may not to have to be a whole number, so I changed _currentFrame from type integer to type number. This fixed the error message for me.
